### PR TITLE
Use `github` instead of `source` in Foreman file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Common use-cases:
 ### Foreman
 Add `rbxcloud` under the `[tools]` section of your `foreman.toml` file:
 ```toml
-rbxcloud = { source = "Sleitnick/rbx-cloud-cli", version = "0.1.0-alpha.2" }
+rbxcloud = { github = "Sleitnick/rbx-cloud-cli", version = "0.1.0-alpha.2" }
 ```
 
 ## Experience


### PR DESCRIPTION
This helps with future proofing, since `source` as a short form for GitHub repositories is only kept for compatibility right now.